### PR TITLE
Prefactor 4: Encapsulate all MyMints operations into the Use Case

### DIFF
--- a/ui/mymints/src/main/java/com/solanamobile/mintyfresh/mymints/repository/NftInfraFactory.kt
+++ b/ui/mymints/src/main/java/com/solanamobile/mintyfresh/mymints/repository/NftInfraFactory.kt
@@ -1,0 +1,31 @@
+package com.solanamobile.mintyfresh.mymints.repository
+
+import com.metaplex.lib.drivers.indenty.ReadOnlyIdentityDriver
+import com.metaplex.lib.drivers.rpc.JdkRpcDriver
+import com.metaplex.lib.drivers.solana.Commitment
+import com.metaplex.lib.drivers.solana.SolanaConnectionDriver
+import com.metaplex.lib.drivers.solana.TransactionOptions
+import com.metaplex.lib.drivers.storage.OkHttpSharedStorageDriver
+import com.metaplex.lib.modules.nfts.NftClient
+import com.solana.core.PublicKey
+import okhttp3.OkHttpClient
+import java.net.URL
+import javax.inject.Inject
+
+class NftInfraFactory @Inject constructor() {
+
+    val storageDriver = OkHttpSharedStorageDriver(OkHttpClient())
+
+    fun createNftClient(pubkey: PublicKey): NftClient {
+        val connection = SolanaConnectionDriver(
+            JdkRpcDriver(URL("https://api.devnet.solana.com")),  //TODO: This will come from networking layer
+            TransactionOptions(Commitment.CONFIRMED, skipPreflight = true)
+        )
+
+        val identityDriver = ReadOnlyIdentityDriver(pubkey, connection)
+        val nftClient = NftClient(connection, identityDriver)
+
+        return nftClient
+    }
+
+}

--- a/ui/mymints/src/main/java/com/solanamobile/mintyfresh/mymints/usecase/MetaplexToCacheMapper.kt
+++ b/ui/mymints/src/main/java/com/solanamobile/mintyfresh/mymints/usecase/MetaplexToCacheMapper.kt
@@ -1,18 +1,13 @@
-package com.solanamobile.mintyfresh.mymints.viewmodels.mapper
+package com.solanamobile.mintyfresh.mymints.usecase
 
 import com.metaplex.lib.modules.nfts.models.JsonMetadata
 import com.metaplex.lib.modules.nfts.models.NFT
-import com.solanamobile.mintyfresh.mymints.viewmodels.viewstate.MyMintsViewState
 import com.solanamobile.mintyfresh.persistence.diskcache.MyMint
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class MyMintsMapper @Inject constructor() {
-
-    fun mapLoading() = MyMintsViewState.Loading(
-        MutableList(10) { index -> MyMint(index.toString(), "", "", "", "", "") }
-    )
+class MetaplexToCacheMapper @Inject constructor() {
 
     fun map(nfts: List<NFT>, rpcClusterName: String) = nfts.map { nft ->
         MyMint(

--- a/ui/mymints/src/main/java/com/solanamobile/mintyfresh/mymints/viewmodels/mapper/CacheToViewStateMapper.kt
+++ b/ui/mymints/src/main/java/com/solanamobile/mintyfresh/mymints/viewmodels/mapper/CacheToViewStateMapper.kt
@@ -1,0 +1,18 @@
+package com.solanamobile.mintyfresh.mymints.viewmodels.mapper
+
+import com.solanamobile.mintyfresh.mymints.viewmodels.viewstate.MintedMedia
+import com.solanamobile.mintyfresh.persistence.diskcache.MyMint
+import javax.inject.Inject
+
+class CacheToViewStateMapper @Inject constructor() {
+
+    fun mapMintToViewState(nft: MyMint): MintedMedia {
+        return MintedMedia(
+            id = nft.id,
+            mediaUrl = nft.mediaUrl,
+            name = nft.name ?: "",
+            description = nft.description ?: ""
+        )
+    }
+
+}

--- a/ui/mymints/src/main/java/com/solanamobile/mintyfresh/mymints/viewmodels/viewstate/MyMintsViewState.kt
+++ b/ui/mymints/src/main/java/com/solanamobile/mintyfresh/mymints/viewmodels/viewstate/MyMintsViewState.kt
@@ -1,14 +1,19 @@
 package com.solanamobile.mintyfresh.mymints.viewmodels.viewstate
 
-import com.solanamobile.mintyfresh.persistence.diskcache.MyMint
+data class MintedMedia(
+    val id: String = "",
+    val mediaUrl: String = "",
+    val name: String = "",
+    val description: String = ""
+)
 
 sealed class MyMintsViewState(
-    val myMints: List<MyMint> = listOf(),
+    val myMints: List<MintedMedia> = listOf(),
 ) {
 
-    class Loading(myMints: List<MyMint>) : MyMintsViewState(myMints)
+    class Loading(myMints: List<MintedMedia>) : MyMintsViewState(myMints)
 
-    class Loaded(myMints: List<MyMint>) : MyMintsViewState(myMints)
+    class Loaded(myMints: List<MintedMedia>) : MyMintsViewState(myMints)
 
     class Empty : MyMintsViewState()
 


### PR DESCRIPTION
The primary goal of this PR is to move all of the logic around loading My Mints into the UseCase. The idea being that the UseCase is the point of abstraction around 

1.) Querying the API and 
2.) managing dealing with the cache.

This way when we have the networking module we can swap out the network implementation and modify caching huerestics.