### PR TITLE
Remove audio recording permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,6 @@
         android:maxSdkVersion="32" />
 
     <uses-feature android:name="android.hardware.camera.any" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />
 

--- a/ui/gallery/src/main/java/com/solanamobile/mintyfresh/gallery/Camera.kt
+++ b/ui/gallery/src/main/java/com/solanamobile/mintyfresh/gallery/Camera.kt
@@ -52,8 +52,7 @@ fun Camera(
 ) {
     val permissionsRequired =
         mutableListOf(
-            Manifest.permission.CAMERA,
-            Manifest.permission.RECORD_AUDIO
+            Manifest.permission.CAMERA
         ).apply {
             if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
                 add(Manifest.permission.WRITE_EXTERNAL_STORAGE)


### PR DESCRIPTION
This is not really needed when capturing images only although the codelabs for cameraX make it seem like this would be required irrespective.