### PR TITLE
NFT.Storage Cleanup

### DIFF
--- a/libs/mintycore/build.gradle.kts
+++ b/libs/mintycore/build.gradle.kts
@@ -25,12 +25,7 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
 
-        //TODO: All of these values will come from the networking layer when that is refactored
-        buildConfigField(
-            "String",
-            "NFTSTORAGE_KEY",
-            "\"${properties.getProperty("NFTSTORAGE_API_KEY")}\""
-        )
+        // NFT.Storage API Url
         buildConfigField("String", "API_BASE_URL", "\"https://api.nft.storage/\"")
     }
 
@@ -39,11 +34,7 @@ android {
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
 
-            buildConfigField(
-                "String",
-                "NFTSTORAGE_KEY",
-                "\"${properties.getProperty("NFTSTORAGE_API_KEY")}\""
-            )
+            // NFT.Storage API Url
             buildConfigField("String", "API_BASE_URL", "\"https://api.nft.storage/\"")
         }
     }

--- a/libs/mintycore/src/main/java/com/solanamobile/mintyfresh/mintycore/usecase/CarFileUseCase.kt
+++ b/libs/mintycore/src/main/java/com/solanamobile/mintyfresh/mintycore/usecase/CarFileUseCase.kt
@@ -34,7 +34,7 @@ class CarFileUseCase @Inject constructor(
         }).encode()
 
         val mediaFileCid = cidUseCase.getRootContentId(mediaFileRoot)
-        val imageUrl = storageRepository.getNftStorageLinkForCid(mediaFileCid)
+        val imageUrl = storageRepository.getIpfsLinkForCid(mediaFileCid)
 
         // build the nft metadata (json)
         val metadataJson = buildNftMetadata(title, description, imageUrl, mediaMimeType)


### PR DESCRIPTION
- removed the NFT.storgae api key stuff from gradle files 
- switched to ipfs urls in all places (both metadata and image link will be `https://ipfs.io/ipfs/###` links now)