### PR TITLE
Fix README formatting for non-desktop layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-    <img src="assets/banner.png" width="800px" height="150px" />
+    <img src="assets/banner.png" width="800px" />
 </div>
 
 <div align="center">
@@ -23,9 +23,9 @@ Mint your favorite photos as NFTs, on the go!
 
 ## Take a Look 
 
-| Your photos                                | Easy to mint                              | On the go                                  | Wherever you are                          |
-|--------------------------------------------|-------------------------------------------|--------------------------------------------|-------------------------------------------|
- <img src="assets/screen1.png" width="250"> | <img src="assets/screen2.png" width="250"> | <img src="assets/screen3.png" width="250"> | <img src="assets/screen4.png" width="250"> |
+Mint | On | Your | Device!
+---|---|---|---
+<img src="assets/screen1.png" width="250"> | <img src="assets/screen2.png" width="250"> | <img src="assets/screen3.png" width="250"> | <img src="assets/screen4.png" width="250"> |
 
 ## Technologies
 


### PR DESCRIPTION
This is what it looks like now on a non-desktop layout:

<img width="422" alt="layout" src="https://user-images.githubusercontent.com/2018851/218576003-bef2e15d-0f9d-4acb-8d6a-423b9ccd409c.png">
