### PR TITLE
Do something with the result for waiting for confirmations.

### DIFF
--- a/libs/mintycore/src/main/java/com/solanamobile/mintyfresh/mintycore/repository/SendTransactionRepository.kt
+++ b/libs/mintycore/src/main/java/com/solanamobile/mintyfresh/mintycore/repository/SendTransactionRepository.kt
@@ -1,11 +1,13 @@
 package com.solanamobile.mintyfresh.mintycore.repository
 
 import android.content.Context
+import com.metaplex.lib.drivers.solana.Commitment
 import com.metaplex.lib.drivers.solana.Connection
 import com.metaplex.lib.drivers.solana.sendTransaction
 import com.solana.core.Transaction
 import com.solanamobile.mintyfresh.mintycore.R
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
@@ -20,27 +22,33 @@ class SendTransactionRepository @Inject constructor(
     suspend fun confirmTransaction(transactionSignature: String): Result<Boolean> =
         withTimeout(connectionDriver.transactionOptions.timeout.toMillis()) {
 
-            val commitment = connectionDriver.transactionOptions.commitment.toString()
+            val requiredCommitment = connectionDriver.transactionOptions.commitment.ordinal
 
             suspend fun confirmationStatus() =
                 connectionDriver.getSignatureStatuses(listOf(transactionSignature), null)
                     .getOrNull()?.first()?.also {
                         it.err?.let { error ->
-                            Result.failure<Boolean>(Error("${context.getString(R.string.transaction_failure_message)}\n$error"))
+                            throw Error("${context.getString(R.string.transaction_failure_message)}\n$error")
                         }
                     }
 
             // wait for desired transaction status
-            while (confirmationStatus()?.confirmationStatus == commitment) {
+            var inc = 1L
+            while (true) {
+                val currentStatus = confirmationStatus()?.confirmationStatus
+                val confirmationEnum =
+                    Commitment.values().firstOrNull { it.name.equals(currentStatus, true) }
+                val confirmationOrdinal = confirmationEnum?.ordinal ?: -1
 
-                // wait a bit before retrying
-                val millis = System.currentTimeMillis()
-                var inc = 0
-                while (System.currentTimeMillis() - millis < 300 && isActive) {
-                    inc++
+                if (confirmationOrdinal >= requiredCommitment) {
+                    return@withTimeout Result.success(true)
+                } else {
+                    // Exponential delay before retrying.
+                    delay(500 * inc)
                 }
-
-                if (!isActive) break // breakout after timeout
+                // breakout after timeout
+                if (!isActive) break
+                inc++
             }
 
             return@withTimeout Result.success(isActive)

--- a/libs/mintycore/src/main/java/com/solanamobile/mintyfresh/mintycore/usecase/PerformMintUseCase.kt
+++ b/libs/mintycore/src/main/java/com/solanamobile/mintyfresh/mintycore/usecase/PerformMintUseCase.kt
@@ -192,7 +192,7 @@ class PerformMintUseCase @Inject constructor(
                 _mintState.value = MintState.AwaitingConfirmation
 
                 // Await for transaction confirmation
-                sendTransactionRepository.confirmTransaction(transactionSignature)
+                val isConfirmed = sendTransactionRepository.confirmTransaction(transactionSignature)
                     .getOrElse {
                         _mintState.value = MintState.Error(
                             it.message
@@ -201,7 +201,12 @@ class PerformMintUseCase @Inject constructor(
                         return@withContext
                     }
 
-                _mintState.value = MintState.Complete(transactionSignature)
+                if (isConfirmed) {
+                    _mintState.value = MintState.Complete(transactionSignature)
+                } else {
+                    _mintState.value =
+                        MintState.Error(context.getString(R.string.transaction_confirmation_failure_message))
+                }
             }
             is TransactionResult.Failure -> {
                 _mintState.value = MintState.Error(txResult.message)


### PR DESCRIPTION
1. Actually throw an error and fail confirmation.
2. Exponential delay when checking for confirmations. .5s then 1s, 2s, 4s .. so on until timeout.
3. Initial delay between sending transaction and checking for confirmations.
4. use delay(long) instead of while loop.
5. Fix the condition in while loop. (this was always false before so we never went inside the loop to actually wait for the confirmations.)

Fixes #132 