### PR TITLE
Update proguard rule to keep constructors from Builder classes 

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -14,3 +14,10 @@
     public static *** i(...);
 }
 # =========== End log messages ===================
+
+# ========== Prevent stripping constructors for GPA builders in metaplex library ==================
+# https://github.com/metaplex-foundation/metaplex-android/blob/1.4.1/lib/src/main/java/com/metaplex/lib/shared/GpaBuilder.kt#L52
+# Following code invokes constructor which is stripped by proguard.
+-keep public class com.metaplex.lib.programs.token_metadata.gpa_builders.** {
+  public protected *;
+}

--- a/libs/mintycore/build.gradle.kts
+++ b/libs/mintycore/build.gradle.kts
@@ -31,7 +31,6 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
 
             // NFT.Storage API Url

--- a/libs/networkConfigs/build.gradle.kts
+++ b/libs/networkConfigs/build.gradle.kts
@@ -19,7 +19,6 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/libs/networkInterface/build.gradle.kts
+++ b/libs/networkInterface/build.gradle.kts
@@ -23,7 +23,6 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/libs/networkInterfaceImpl/build.gradle.kts
+++ b/libs/networkInterfaceImpl/build.gradle.kts
@@ -24,7 +24,6 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/libs/persistence/build.gradle.kts
+++ b/libs/persistence/build.gradle.kts
@@ -19,7 +19,6 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }

--- a/ui/commonComposable/build.gradle.kts
+++ b/ui/commonComposable/build.gradle.kts
@@ -27,7 +27,6 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/ui/gallery/build.gradle.kts
+++ b/ui/gallery/build.gradle.kts
@@ -25,7 +25,6 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/ui/mymints/build.gradle.kts
+++ b/ui/mymints/build.gradle.kts
@@ -27,7 +27,6 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/ui/nftMint/build.gradle.kts
+++ b/ui/nftMint/build.gradle.kts
@@ -18,7 +18,6 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }

--- a/ui/settings/build.gradle.kts
+++ b/ui/settings/build.gradle.kts
@@ -25,7 +25,6 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/ui/walletConnectButton/build.gradle.kts
+++ b/ui/walletConnectButton/build.gradle.kts
@@ -19,7 +19,6 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }


### PR DESCRIPTION
In metaplex library the code is being invoked indirectly from internal java methods by accessing constructor list 

See https://github.com/metaplex-foundation/metaplex-android/blob/1.4.1/lib/src/main/java/com/metaplex/lib/shared/GpaBuilder.kt#L52

Proguard assumes the constructors to be unused and strip those out of build causing runtime failures. 