### PR TITLE
Apply mint signature before sending to wallets for signing

### DIFF
--- a/libs/mintycore/src/main/java/com/solanamobile/mintyfresh/mintycore/usecase/PerformMintUseCase.kt
+++ b/libs/mintycore/src/main/java/com/solanamobile/mintyfresh/mintycore/usecase/PerformMintUseCase.kt
@@ -143,6 +143,10 @@ class PerformMintUseCase @Inject constructor(
             return@withContext
         }
 
+        // Apply the mint signature first. This ensures that wallets won't try to modify the txn,
+        // which will break the txn re-creation workaround we have in place below.
+        mintTxn.partialSign(mintAccount)
+
         val transactionBytes =
             mintTxn.serialize(
                 SerializeConfig(


### PR DESCRIPTION
This prevents wallets from modifying the transaction (for e.g., by adding priority fees). This allows for the current workaround of reconstructing the transaction manually.