### PR TITLE
Fix Metadata File URL

### DIFF
--- a/libs/mintycore/src/main/java/com/solanamobile/mintyfresh/mintycore/ipld/CarFile.kt
+++ b/libs/mintycore/src/main/java/com/solanamobile/mintyfresh/mintycore/ipld/CarFile.kt
@@ -1,9 +1,10 @@
 package com.solanamobile.mintyfresh.mintycore.ipld
 
-class CarFile(val rootCid: CID) {
+import androidx.annotation.Size
 
-    val headerBlock = buildHeader(listOf(rootCid))
-    val dataBlocks = mutableMapOf<CID, ByteArray>()
+open class CarFile(val rootCid: CID, val dataBlocks: Map<CID, ByteArray>) {
+
+    private val headerBlock = buildHeader(listOf(rootCid))
 
     /*
      * https://ipld.io/specs/transport/car/carv1/#format-description
@@ -20,9 +21,37 @@ class CarFile(val rootCid: CID) {
                     listOf( Varint.encode(cid.bytes.size + data.size) + cid.bytes + data )
                 }.reduce{ a, d -> a + d }
 
-    fun add(cid: CID, data: ByteArray): CarFile {
-        dataBlocks.put(cid, data)
-        return this
+    open class Builder {
+
+        private var rootCid: CID? = null
+        private val dataBlocks = mutableMapOf<CID, ByteArray>()
+
+        fun add(cid: CID, @Size(max = MAX_BLOCK_SIZE.toLong()) data: ByteArray,
+                isRoot: Boolean = false): Builder {
+            dataBlocks[cid] = data
+            if (isRoot) setRoot(cid)
+            return this
+        }
+
+        fun add(blocks: Map<CID, ByteArray>): Builder {
+            blocks.forEach { (cid, data) -> add(cid, data) }
+            return this
+        }
+
+        fun addRoot(rootCid: CID, @Size(max = MAX_BLOCK_SIZE.toLong()) data: ByteArray) =
+            add(rootCid, data, true)
+
+        fun setRoot(rootCid: CID): Builder {
+            this.rootCid = rootCid
+            return this
+        }
+
+        open fun build(): CarFile {
+            check(rootCid != null) { "Invalid Root: no Root CID was provided" }
+            check(dataBlocks.containsKey(rootCid)) { "Invalid Root: Root CID not found" }
+
+            return CarFile(rootCid!!, dataBlocks)
+        }
     }
 
     // https://ipld.io/specs/transport/car/carv1/#header
@@ -32,4 +61,7 @@ class CarFile(val rootCid: CID) {
                 "roots" to rootCids,
                 "version" to 1
             ))
+    companion object {
+        const val MAX_BLOCK_SIZE = 1 shl 20 // 1MB
+    }
 }

--- a/libs/mintycore/src/main/java/com/solanamobile/mintyfresh/mintycore/ipld/CarFileDirectory.kt
+++ b/libs/mintycore/src/main/java/com/solanamobile/mintyfresh/mintycore/ipld/CarFileDirectory.kt
@@ -1,0 +1,61 @@
+package com.solanamobile.mintyfresh.mintycore.ipld
+
+import com.solanamobile.mintyfresh.mintycore.usecase.Web3IdUseCase
+
+class CarFileDirectory(rootCid: CID, data: Map<CID, ByteArray>)
+    : CarFile(rootCid, data) {
+
+    class Builder(val cidUseCase: Web3IdUseCase): CarFile.Builder() {
+
+        private val links = mutableListOf<PBLink>()
+
+        fun addDirectory(name: String, files: Map<String, ByteArray>) {
+            val links = mutableListOf<PBLink>()
+
+            files.forEach { (fileName, data) ->
+                addFile(fileName, data) { cid ->
+                    links.add(PBLink(fileName, data.size, cid))
+                }
+            }
+
+            val rootNode = IpdlDirectory(links).encode()
+            val rootCid = cidUseCase.getRootContentId(rootNode)
+            add(rootCid, rootNode)
+            links.add(PBLink(name, rootNode.size, rootCid))
+        }
+
+        fun addFile(fileName: String, data: ByteArray,
+                    cidCallback: (Builder.(CID) -> Unit)? = null): Builder {
+            val (cid, block) = if (data.size > MAX_BLOCK_SIZE) {
+                val fileBlocks = data.asIterable().chunked(MAX_BLOCK_SIZE).associate { chunk ->
+                    val chunkBytes = chunk.toByteArray()
+                    cidUseCase.getContentId(chunkBytes) to chunkBytes
+                }
+
+                add(fileBlocks)
+
+                val fileRoot = IpdlFile(fileBlocks.map { (cid, data) ->
+                    PBLink(null, data.size, cid)
+                }).encode()
+
+                cidUseCase.getRootContentId(fileRoot) to fileRoot
+            } else {
+                cidUseCase.getContentId(data) to data
+            }
+
+            add(cid, block)
+            links.add(PBLink(fileName, data.size, cid))
+            cidCallback?.invoke(this, cid)
+
+            return this
+        }
+
+        override fun build(): CarFile {
+            val rootNode = IpdlDirectory(links).encode()
+            val rootCid = cidUseCase.getRootContentId(rootNode)
+            addRoot(rootCid, rootNode)
+
+            return super.build()
+        }
+    }
+}


### PR DESCRIPTION
fixes issue reported by user: https://discord.com/channels/988649555283308564/1126619734683693056

### Summary
We were using a metadata URL that linked to the metadata file via its root cid + file name:
```
https://ipfs.io//ipfs/{rootCid}/{NFT Title}.json
```
which might fail to resolve if the NFT Title contained any unsafe characters. The better way to link to file is to use its cid directly:
```
https://ipfs.io//ipfs/{metadataCid}
```

### Work Completed
We had an outstanding TODO to fix the metadata URL that was causing this bug, this PR addresses that TODO.

I took the opportunity to improve the IPLD/CAR abstractions. The NFT files are uploaded as an IPDL directory so I refactored all code related to building the CAR file directory  to its own abstraction. This was not strictly necessary for this fix, but it makes the directory upload code usable for uploading any generic file directory.  

### Testing
Minted some NFTs with special characters:
- https://explorer.solana.com/address/9X8B6rUqeUDV3NLQiRJgN8zYacn6NEh24y8hNapSm2Sa?cluster=devnet
- https://explorer.solana.com/address/7GSTwgriiRBRBMp153YcC9ZFHkvuY1D44QKz5jLebgYK?cluster=devnet
- https://explorer.solana.com/address/2iCAdJeMyaLcTBsb6o84LeF7LyyZrdDa9mhDdr4Rk4u7?cluster=devnet