### PR TITLE
Fix Protobuf link name size

### DIFF
--- a/libs/mintycore/src/main/java/com/solanamobile/mintyfresh/mintycore/ipld/DagPB.kt
+++ b/libs/mintycore/src/main/java/com/solanamobile/mintyfresh/mintycore/ipld/DagPB.kt
@@ -42,7 +42,7 @@ fun PBNode.encode(): ByteArray {
  */
 fun PBLink.encode() =
     byteArrayOf(0x0a) + cid.bytes.size.asVarint() + cid.bytes +                     // link cid
-            (name?.let {                                                            // link name
-                byteArrayOf(0x12) + name.length.asVarint() + name.encodeToByteArray()
+            (name?.encodeToByteArray()?.let { nameBytes ->                                       // link name
+                byteArrayOf(0x12) + nameBytes.size.asVarint() + nameBytes
             } ?: byteArrayOf()) +
             byteArrayOf(0x18) + size.asVarint()                                     // link size


### PR DESCRIPTION
### Summary 
Size calculation for the protobuf file links name field was incorrect, it was using the string character length instead of the encoded bytes length 

NFT titles with 16bit characters would cause an 500 when uploading the files due to the protobuf encoding error

### Testing
https://explorer.solana.com/address/8gvxxUC3BCYYbQixkfXpcg45YacQsZPrH1wMNaGmtJ9q/metadata?cluster=devnet