### PR TITLE
Fix "Name too long" error

### DIFF
--- a/libs/mintycore/src/main/java/com/solanamobile/mintyfresh/mintycore/repository/MintTransactionRepository.kt
+++ b/libs/mintycore/src/main/java/com/solanamobile/mintyfresh/mintycore/repository/MintTransactionRepository.kt
@@ -22,7 +22,8 @@ class MintTransactionRepository @Inject constructor(private val connectionDriver
         }
 
     private fun createNftMetadata(title: String, metadataUrl: String, creator: PublicKey) = Metadata(
-        name = title,
+        name = title.truncateBytes(NFT_NAME_BYTE_LIMIT),
+        // uri must be < 204 bytes, not checked here because IPFS links will always be less
         uri = metadataUrl,
         sellerFeeBasisPoints = 0,
         creators = listOf(
@@ -30,4 +31,17 @@ class MintTransactionRepository @Inject constructor(private val connectionDriver
             Creator(PublicKey(mintyFreshCreatorPubKey), false, 0.toUByte())
         ),
     )
+
+    // truncates a string to a max number of bytes, preserving character boundaries
+    private fun String.truncateBytes(maxBytes: Int): String {
+        var count = 0
+        return this.takeWhile {
+            count += if (it.code <= 0x007F) 1 else if (it.code <= 0x07FF) 2 else 3
+            count < maxBytes
+        }
+    }
+
+    companion object {
+        private const val NFT_NAME_BYTE_LIMIT = 32
+    }
 }


### PR DESCRIPTION
### Summary
fixes [this error](https://explorer.solana.com/tx/4ci3cW7ybkmDUoYTYFWSypDaGrpPNpVHe9kKVAaCta6yUAjPYz52xoUKmW1jBYCtXoN4bfNk3Gbq8Wu6k4MVoR5D?cluster=devnet), caused by the on chain NFT name exceeding 32 bytes.

The NFT name that is stored in the on chain Metaplex NFT Metadata account must be 32 bytes or less. We currently limit the NFT title input field to 32 characters, not bytes. This PR truncates the on chain name to 32 bytes. The off chain metadata still shows the full name, so wallets etc will still display the full name. Only the on chain data is truncated. 